### PR TITLE
Port to Minecraft 26.2

### DIFF
--- a/Fabric/src/main/java/com/yungnickyoung/minecraft/travelerstitles/mixin/RenderGuiTickMixinFabric.java
+++ b/Fabric/src/main/java/com/yungnickyoung/minecraft/travelerstitles/mixin/RenderGuiTickMixinFabric.java
@@ -2,14 +2,14 @@ package com.yungnickyoung.minecraft.travelerstitles.mixin;
 
 import com.yungnickyoung.minecraft.travelerstitles.TravelersTitlesCommon;
 import net.minecraft.client.DeltaTracker;
-import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.Hud;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(Gui.class)
+@Mixin(Hud.class)
 public class RenderGuiTickMixinFabric {
     @Inject(method = "extractRenderState", at = @At(value = "HEAD"))
     private void travelerstitles_onClientTick(GuiGraphicsExtractor guiGraphics, DeltaTracker deltaTracker, CallbackInfo ci) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,16 +11,16 @@ mod_description=Epic, RPG-like titles when entering biomes & dimensions
 mod_credits=Thanks so much to all my patrons!
 license=LGPLv3
 maven_group=com.yungnickyoung.minecraft.travelerstitles
-mc_version=26.1.2
-mc_version_range=[26.1,)
-mc_version_range_fabric=>=26.1
+mc_version=26.2
+mc_version_range=[26.2,)
+mc_version_range_fabric=>=26.2
 ## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
 ## https://projects.neoforged.net/neoforged/neoform
-mc_version_neo_form=26.1.2-1
+mc_version_neo_form=26.2-2
 
 # CurseForge/Modrinth Publishing
 cursegradle_version=1.1.24
-compatible_versions=26.1.1,26.1.2
+compatible_versions=26.2
 curseforge_project_id_fabric=590990
 curseforge_project_id_neoforge=504908
 modrinth_project_id=JtifUr64
@@ -30,14 +30,14 @@ debug_publish=true
 yungsapi_version=6.1.0
 
 # Fabric
-fabric_version=0.150.0
-fabric_loader_version=0.18.6
-clothconfig_version_fabric=26.1.154
-modmenu_version_fabric=18.0.0-beta.1
+fabric_version=0.154.2
+fabric_loader_version=0.19.3
+clothconfig_version_fabric=26.2.155
+modmenu_version_fabric=20.0.1
 
 # NeoForge
-neoforge_version=26.1.2.75
-neoforge_version_range=[26.1.2.75,)
+neoforge_version=26.2.0.41-beta
+neoforge_version_range=[26.2.0.41-beta,)
 neoforge_loader_version_range=[4,)
 waystones_version=26.1.2.5
 balm_version=26.1.2.6


### PR DESCRIPTION
## Summary

- update the Minecraft, Fabric, Fabric API, Cloth Config, Mod Menu, NeoForm, and NeoForge targets for Minecraft 26.2
- migrate the Minecraft 26.2 APIs and data formats used by this project
- keep the Common, Fabric, and NeoForge modules aligned with the YUNG's API 26.2 port

Depends on YUNG-GANG/YUNGs-API#109.

## Validation

- `gradlew build --no-daemon --console=plain` passes for Common, Fabric, and NeoForge on Java 25
- Fabric client and server startup were validated in a Minecraft 26.2 PrismLauncher instance
- the build was tested against the Common, Fabric, and NeoForge artifacts from the YUNG's API 26.2 port

The existing LGPL-3.0 license is preserved.
